### PR TITLE
Add custom exception on empty list Next() method call

### DIFF
--- a/src/RoundRobin/RoundRobinList.cs
+++ b/src/RoundRobin/RoundRobinList.cs
@@ -131,6 +131,9 @@ namespace RoundRobin
         {
             lock (_lock)
             {
+                if (_linkedList.Count == 0)
+                    throw new InvalidOperationException("List is empty.");
+
                 if (_current == null) _current = _linkedList.First;
                 else
                 {

--- a/test/RoundRobin.Test/GeneralTests.cs
+++ b/test/RoundRobin.Test/GeneralTests.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace RoundRobin.Test
+{
+    public class GeneralTests
+    {
+        [Test]
+        public void EmptyListNext()
+        {
+            var rb = new RoundRobinList<int>(Array.Empty<int>());
+
+            Assert.Throws<InvalidOperationException>(() =>
+            {
+                rb.Next();
+            });
+        }
+
+    }
+}


### PR DESCRIPTION
Currently, `NullReferenceException` is thrown by the `Next()` method when the list is empty.
I also have added the test.